### PR TITLE
Add Android SMS-first Expense Tracker starter skeleton (app module + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-My First Repository
-Hello Sugar Labs
+# My First Repository
+
+Android starter project files for an SMS-first expense tracker prototype are now included directly in this repository.
+
+## What is included
+- Android module under `app/`
+- Kotlin skeleton classes for parser, SMS receiver, notification listener, and quick-add UI
+- Basic Room entities/DAO/database skeleton
+- Manifest, resources, and Gradle files
+- Original implementation guide in `STARTER_SKELETON.md`

--- a/STARTER_SKELETON.md
+++ b/STARTER_SKELETON.md
@@ -1,0 +1,333 @@
+# Expense Tracker Android Starter Skeleton (SMS-first)
+
+This starter keeps **SMS as the primary transaction source** and includes a **NotificationListener test path**.
+
+## 1) Create project in Android Studio
+
+1. Open Android Studio → **New Project** → **Empty Activity**.
+2. Name: `ExpenseTracker`.
+3. Package: `com.example.expensetracker`.
+4. Language: **Kotlin**.
+5. Min SDK: **26+** (recommended).
+6. Finish and let Gradle sync.
+
+## 2) Suggested package structure
+
+```text
+app/src/main/java/com/example/expensetracker/
+  data/
+    ExpenseDraft.kt
+    ExpenseEntity.kt
+    ExpenseDao.kt
+    AppDatabase.kt
+  parser/
+    SmsParser.kt
+    GenericUpiSmsParser.kt
+  receiver/
+    BankSmsReceiver.kt
+  service/
+    PaymentNotificationListenerService.kt
+  ui/
+    MainActivity.kt
+    QuickAddActivity.kt
+  util/
+    DraftIntents.kt
+```
+
+## 3) Gradle dependencies (`app/build.gradle.kts`)
+
+```kotlin
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.activity:activity-ktx:1.9.2")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+
+    testImplementation("junit:junit:4.13.2")
+}
+```
+
+Also enable kapt plugin in the same file:
+
+```kotlin
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.kapt")
+}
+```
+
+## 4) Manifest setup (`app/src/main/AndroidManifest.xml`)
+
+```xml
+<manifest ...>
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application ...>
+        <activity
+            android:name=".ui.QuickAddActivity"
+            android:theme="@style/Theme.ExpenseTracker.Popup" />
+
+        <receiver
+            android:name=".receiver.BankSmsReceiver"
+            android:exported="true"
+            android:permission="android.permission.BROADCAST_SMS">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name=".service.PaymentNotificationListenerService"
+            android:label="Expense Tracker Listener"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>
+```
+
+> Production note: SMS permissions are Play-policy sensitive; this setup is intended for local prototyping.
+
+## 5) Core model classes
+
+### `ExpenseDraft.kt`
+
+```kotlin
+package com.example.expensetracker.data
+
+data class ExpenseDraft(
+    val amount: Double?,
+    val timestampMillis: Long,
+    val payee: String?,
+    val title: String?,
+    val category: String? = null,
+    val source: String, // "sms" or "notification"
+    val rawText: String
+)
+```
+
+### `ExpenseEntity.kt`
+
+```kotlin
+package com.example.expensetracker.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "expenses")
+data class ExpenseEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val amount: Double,
+    val timestampMillis: Long,
+    val title: String,
+    val category: String,
+    val source: String,
+    val rawText: String
+)
+```
+
+## 6) SMS parser skeleton
+
+### `SmsParser.kt`
+
+```kotlin
+package com.example.expensetracker.parser
+
+import com.example.expensetracker.data.ExpenseDraft
+
+interface SmsParser {
+    fun parse(message: String, timestampMillis: Long): ExpenseDraft?
+}
+```
+
+### `GenericUpiSmsParser.kt`
+
+```kotlin
+package com.example.expensetracker.parser
+
+import com.example.expensetracker.data.ExpenseDraft
+
+class GenericUpiSmsParser : SmsParser {
+    private val amountRegex = Regex("(?:₹|Rs\\.?|INR)\\s?([0-9]+(?:\\.[0-9]{1,2})?)", RegexOption.IGNORE_CASE)
+    private val payeeRegex = Regex("(?:to|towards)\\s+([A-Za-z0-9 .&_-]{2,40})", RegexOption.IGNORE_CASE)
+
+    override fun parse(message: String, timestampMillis: Long): ExpenseDraft? {
+        val lower = message.lowercase()
+        val hasDebitSignal = listOf("debited", "spent", "sent", "upi", "paid").any { it in lower }
+        if (!hasDebitSignal) return null
+
+        val amount = amountRegex.find(message)?.groupValues?.getOrNull(1)?.toDoubleOrNull()
+        val payee = payeeRegex.find(message)?.groupValues?.getOrNull(1)?.trim()
+
+        return ExpenseDraft(
+            amount = amount,
+            timestampMillis = timestampMillis,
+            payee = payee,
+            title = payee ?: "UPI Expense",
+            source = "sms",
+            rawText = message
+        )
+    }
+}
+```
+
+## 7) SMS receiver skeleton
+
+### `BankSmsReceiver.kt`
+
+```kotlin
+package com.example.expensetracker.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Telephony
+import com.example.expensetracker.parser.GenericUpiSmsParser
+import com.example.expensetracker.util.DraftIntents
+
+class BankSmsReceiver : BroadcastReceiver() {
+    private val parser = GenericUpiSmsParser()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Telephony.Sms.Intents.SMS_RECEIVED_ACTION) return
+
+        val bundle: Bundle = intent.extras ?: return
+        val smsMessages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
+        val body = smsMessages.joinToString(separator = "") { it.messageBody ?: "" }
+        val timestamp = smsMessages.firstOrNull()?.timestampMillis ?: System.currentTimeMillis()
+
+        val draft = parser.parse(body, timestamp) ?: return
+        context.startActivity(DraftIntents.quickAddIntent(context, draft))
+    }
+}
+```
+
+## 8) Quick-add popup screen skeleton
+
+### `DraftIntents.kt`
+
+```kotlin
+package com.example.expensetracker.util
+
+import android.content.Context
+import android.content.Intent
+import com.example.expensetracker.data.ExpenseDraft
+import com.example.expensetracker.ui.QuickAddActivity
+
+object DraftIntents {
+    fun quickAddIntent(context: Context, draft: ExpenseDraft): Intent {
+        return Intent(context, QuickAddActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra("amount", draft.amount)
+            putExtra("timestamp", draft.timestampMillis)
+            putExtra("payee", draft.payee)
+            putExtra("title", draft.title)
+            putExtra("source", draft.source)
+            putExtra("rawText", draft.rawText)
+        }
+    }
+}
+```
+
+### `QuickAddActivity.kt`
+
+```kotlin
+package com.example.expensetracker.ui
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+import com.example.expensetracker.R
+
+class QuickAddActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_quick_add)
+
+        val amountInput = findViewById<EditText>(R.id.amountInput)
+        val titleInput = findViewById<EditText>(R.id.titleInput)
+        val categoryInput = findViewById<EditText>(R.id.categoryInput)
+        val saveButton = findViewById<Button>(R.id.saveButton)
+
+        amountInput.setText(intent.getDoubleExtra("amount", 0.0).toString())
+        titleInput.setText(intent.getStringExtra("title") ?: "")
+
+        saveButton.setOnClickListener {
+            // TODO: Save with Room DAO and finish.
+            finish()
+        }
+    }
+}
+```
+
+## 9) Notification listener test path
+
+### `PaymentNotificationListenerService.kt`
+
+```kotlin
+package com.example.expensetracker.service
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import com.example.expensetracker.parser.GenericUpiSmsParser
+import com.example.expensetracker.util.DraftIntents
+
+class PaymentNotificationListenerService : NotificationListenerService() {
+    private val parser = GenericUpiSmsParser()
+
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        val extras = sbn.notification.extras
+        val title = extras.getString("android.title") ?: ""
+        val text = extras.getCharSequence("android.text")?.toString() ?: ""
+        val combined = "$title $text".trim()
+
+        val draft = parser.parse(combined, sbn.postTime) ?: return
+        startActivity(DraftIntents.quickAddIntent(this, draft.copy(source = "notification")))
+    }
+}
+```
+
+## 10) Popup layout + theme
+
+Create `res/layout/activity_quick_add.xml` with 3 inputs + save button and a simple vertical layout.
+
+In `res/values/themes.xml`, add:
+
+```xml
+<style name="Theme.ExpenseTracker.Popup" parent="Theme.Material3.DayNight.DialogWhenLarge" />
+```
+
+## 11) Run and test
+
+1. Install app on physical Android device.
+2. Open app once and request runtime permissions for SMS/notifications.
+3. Grant notification access manually in system settings for your app.
+4. Send a test SMS from another phone with content like:
+   - `INR 240.00 debited via UPI to Swiggy Ref 12345`
+5. Verify QuickAdd popup opens with prefilled amount/title.
+6. Optional: post a test notification from your own app and verify listener route.
+
+## 12) Debugging checklist
+
+- Receiver not firing: confirm SMS permission granted and app installed as debug build.
+- No popup: Android background-start restriction can block direct launch; fallback to a high-priority notification that opens `QuickAddActivity` on tap.
+- Wrong parse: log raw SMS and add bank-specific parser class.
+
+## 13) What to build next
+
+- Room persistence wired to `saveButton`
+- Expense list screen in `MainActivity`
+- Dedupe hash (amount + minute bucket + payee)
+- Category suggestion rules

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,51 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.kapt")
+}
+
+android {
+    namespace = "com.example.expensetracker"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.expensetracker"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.activity:activity-ktx:1.9.2")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+
+    testImplementation("junit:junit:4.13.2")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# No custom rules yet.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.expensetracker">
+
+    <uses-feature
+        android:name="android.hardware.telephony"
+        android:required="false" />
+
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
+    <uses-permission android:name="android.permission.READ_SMS" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ExpenseTracker">
+
+        <activity
+            android:name="com.example.expensetracker.ui.QuickAddActivity"
+            android:theme="@style/Theme.ExpenseTracker.Popup" />
+
+        <activity
+            android:name="com.example.expensetracker.ui.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:name="com.example.expensetracker.receiver.BankSmsReceiver"
+            android:exported="true"
+            android:permission="android.permission.BROADCAST_SMS">
+            <intent-filter>
+                <action android:name="android.provider.Telephony.SMS_RECEIVED" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name="com.example.expensetracker.service.PaymentNotificationListenerService"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/expensetracker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/expensetracker/data/AppDatabase.kt
@@ -1,0 +1,9 @@
+package com.example.expensetracker.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(entities = [ExpenseEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun expenseDao(): ExpenseDao
+}

--- a/app/src/main/java/com/example/expensetracker/data/ExpenseDao.kt
+++ b/app/src/main/java/com/example/expensetracker/data/ExpenseDao.kt
@@ -1,0 +1,14 @@
+package com.example.expensetracker.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+
+@Dao
+interface ExpenseDao {
+    @Insert
+    suspend fun insert(expense: ExpenseEntity)
+
+    @Query("SELECT * FROM expenses ORDER BY timestampMillis DESC")
+    suspend fun getAll(): List<ExpenseEntity>
+}

--- a/app/src/main/java/com/example/expensetracker/data/ExpenseDraft.kt
+++ b/app/src/main/java/com/example/expensetracker/data/ExpenseDraft.kt
@@ -1,0 +1,11 @@
+package com.example.expensetracker.data
+
+data class ExpenseDraft(
+    val amount: Double?,
+    val timestampMillis: Long,
+    val payee: String?,
+    val title: String?,
+    val category: String? = null,
+    val source: String,
+    val rawText: String
+)

--- a/app/src/main/java/com/example/expensetracker/data/ExpenseEntity.kt
+++ b/app/src/main/java/com/example/expensetracker/data/ExpenseEntity.kt
@@ -1,0 +1,15 @@
+package com.example.expensetracker.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "expenses")
+data class ExpenseEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val amount: Double,
+    val timestampMillis: Long,
+    val title: String,
+    val category: String,
+    val source: String,
+    val rawText: String
+)

--- a/app/src/main/java/com/example/expensetracker/parser/GenericUpiSmsParser.kt
+++ b/app/src/main/java/com/example/expensetracker/parser/GenericUpiSmsParser.kt
@@ -1,0 +1,26 @@
+package com.example.expensetracker.parser
+
+import com.example.expensetracker.data.ExpenseDraft
+
+class GenericUpiSmsParser : SmsParser {
+    private val amountRegex = Regex("(?:₹|Rs\\.?|INR)\\s?([0-9]+(?:\\.[0-9]{1,2})?)", RegexOption.IGNORE_CASE)
+    private val payeeRegex = Regex("(?:to|towards)\\s+([A-Za-z0-9 .&_-]{2,40})", RegexOption.IGNORE_CASE)
+
+    override fun parse(message: String, timestampMillis: Long): ExpenseDraft? {
+        val lower = message.lowercase()
+        val hasDebitSignal = listOf("debited", "spent", "sent", "upi", "paid").any { it in lower }
+        if (!hasDebitSignal) return null
+
+        val amount = amountRegex.find(message)?.groupValues?.getOrNull(1)?.toDoubleOrNull()
+        val payee = payeeRegex.find(message)?.groupValues?.getOrNull(1)?.trim()
+
+        return ExpenseDraft(
+            amount = amount,
+            timestampMillis = timestampMillis,
+            payee = payee,
+            title = payee ?: "UPI Expense",
+            source = "sms",
+            rawText = message
+        )
+    }
+}

--- a/app/src/main/java/com/example/expensetracker/parser/SmsParser.kt
+++ b/app/src/main/java/com/example/expensetracker/parser/SmsParser.kt
@@ -1,0 +1,7 @@
+package com.example.expensetracker.parser
+
+import com.example.expensetracker.data.ExpenseDraft
+
+interface SmsParser {
+    fun parse(message: String, timestampMillis: Long): ExpenseDraft?
+}

--- a/app/src/main/java/com/example/expensetracker/receiver/BankSmsReceiver.kt
+++ b/app/src/main/java/com/example/expensetracker/receiver/BankSmsReceiver.kt
@@ -1,0 +1,23 @@
+package com.example.expensetracker.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.provider.Telephony
+import com.example.expensetracker.parser.GenericUpiSmsParser
+import com.example.expensetracker.util.DraftIntents
+
+class BankSmsReceiver : BroadcastReceiver() {
+    private val parser = GenericUpiSmsParser()
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Telephony.Sms.Intents.SMS_RECEIVED_ACTION) return
+
+        val smsMessages = Telephony.Sms.Intents.getMessagesFromIntent(intent)
+        val body = smsMessages.joinToString(separator = "") { it.messageBody.orEmpty() }
+        val timestamp = smsMessages.firstOrNull()?.timestampMillis ?: System.currentTimeMillis()
+
+        val draft = parser.parse(body, timestamp) ?: return
+        context.startActivity(DraftIntents.quickAddIntent(context, draft))
+    }
+}

--- a/app/src/main/java/com/example/expensetracker/service/PaymentNotificationListenerService.kt
+++ b/app/src/main/java/com/example/expensetracker/service/PaymentNotificationListenerService.kt
@@ -1,0 +1,20 @@
+package com.example.expensetracker.service
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import com.example.expensetracker.parser.GenericUpiSmsParser
+import com.example.expensetracker.util.DraftIntents
+
+class PaymentNotificationListenerService : NotificationListenerService() {
+    private val parser = GenericUpiSmsParser()
+
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        val extras = sbn.notification.extras
+        val title = extras.getString("android.title").orEmpty()
+        val text = extras.getCharSequence("android.text")?.toString().orEmpty()
+        val combined = "$title $text".trim()
+
+        val draft = parser.parse(combined, sbn.postTime) ?: return
+        startActivity(DraftIntents.quickAddIntent(this, draft.copy(source = "notification")))
+    }
+}

--- a/app/src/main/java/com/example/expensetracker/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/expensetracker/ui/MainActivity.kt
@@ -1,0 +1,12 @@
+package com.example.expensetracker.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.example.expensetracker.R
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/app/src/main/java/com/example/expensetracker/ui/QuickAddActivity.kt
+++ b/app/src/main/java/com/example/expensetracker/ui/QuickAddActivity.kt
@@ -1,0 +1,27 @@
+package com.example.expensetracker.ui
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+import com.example.expensetracker.R
+
+class QuickAddActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_quick_add)
+
+        val amountInput = findViewById<EditText>(R.id.amountInput)
+        val titleInput = findViewById<EditText>(R.id.titleInput)
+        val categoryInput = findViewById<EditText>(R.id.categoryInput)
+        val saveButton = findViewById<Button>(R.id.saveButton)
+
+        amountInput.setText(intent.getDoubleExtra("amount", 0.0).toString())
+        titleInput.setText(intent.getStringExtra("title").orEmpty())
+
+        saveButton.setOnClickListener {
+            categoryInput.text.toString()
+            finish()
+        }
+    }
+}

--- a/app/src/main/java/com/example/expensetracker/util/DraftIntents.kt
+++ b/app/src/main/java/com/example/expensetracker/util/DraftIntents.kt
@@ -1,0 +1,20 @@
+package com.example.expensetracker.util
+
+import android.content.Context
+import android.content.Intent
+import com.example.expensetracker.data.ExpenseDraft
+import com.example.expensetracker.ui.QuickAddActivity
+
+object DraftIntents {
+    fun quickAddIntent(context: Context, draft: ExpenseDraft): Intent {
+        return Intent(context, QuickAddActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            putExtra("amount", draft.amount)
+            putExtra("timestamp", draft.timestampMillis)
+            putExtra("payee", draft.payee)
+            putExtra("title", draft.title)
+            putExtra("source", draft.source)
+            putExtra("rawText", draft.rawText)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Expense Tracker Starter" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_quick_add.xml
+++ b/app/src/main/res/layout/activity_quick_add.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/amountInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Amount" />
+
+    <EditText
+        android:id="@+id/titleInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Title" />
+
+    <EditText
+        android:id="@+id/categoryInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Category" />
+
+    <Button
+        android:id="@+id/saveButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Save" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Expense Tracker</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.ExpenseTracker" parent="Theme.Material3.DayNight.NoActionBar" />
+    <style name="Theme.ExpenseTracker.Popup" parent="Theme.Material3.DayNight.DialogWhenLarge" />
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.application") version "8.6.1" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("org.jetbrains.kotlin.kapt") version "1.9.24" apply false
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ExpenseTracker"
+include(":app")


### PR DESCRIPTION
### Motivation
- Provide a self-contained Android starter for an SMS-first expense tracker with a notification-listener test path and guidance for prototyping.
- Include minimal Room persistence, parser, receiver, quick-add UI, and Gradle/manifest scaffolding to speed local development and demos.

### Description
- Add `STARTER_SKELETON.md` with step-by-step setup, architecture suggestions, and manual test instructions for an SMS-first flow.  
- Add an `app/` module including `build.gradle.kts`, `AndroidManifest.xml`, app resources, and theme files to make the project buildable in Android Studio.  
- Implement Kotlin skeletons: data models (`ExpenseDraft`, `ExpenseEntity`), DAO/DB (`ExpenseDao`, `AppDatabase`), parser (`SmsParser`, `GenericUpiSmsParser`), receiver (`BankSmsReceiver`), notification listener (`PaymentNotificationListenerService`), quick-add UI (`QuickAddActivity`, `MainActivity`), and `DraftIntents` helper.  
- Update top-level `README.md` to describe included starter files and link to the original implementation guide in `STARTER_SKELETON.md`.

### Testing
- No automated tests were executed as part of this change (no CI/unit tests were run in the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afa693d694832f88dc78006d9e5340)